### PR TITLE
fix: allow to upload larger sized image

### DIFF
--- a/src/api-gateway/src/main/resources/application.properties
+++ b/src/api-gateway/src/main/resources/application.properties
@@ -3,3 +3,6 @@ server.port=8081
 
 management.endpoints.web.exposure.include=*
 management.info.env.enabled=true
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB

--- a/src/blob-storage-service/src/main/resources/application.properties
+++ b/src/blob-storage-service/src/main/resources/application.properties
@@ -7,3 +7,6 @@ management.info.env.enabled=true
 spring.cloud.azure.storage.blob.account-name=${STORAGE_ACCOUNT_NAME}
 spring.cloud.azure.storage.blob.endpoint=${STORAGE_ACCOUNT_ENDPOINT}
 storage.blob.container-name=${STORAGE_ACCOUNT_CONTAINER_NAME}
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
The application with return `413 request entity too large` currently when I uploading an image largger than 1MB.
However, the UI says you can upload a max 10 MB image.

This PR fix this issue by override the `max-file-size` and `max-request-size` to 10 MB.